### PR TITLE
patch for gd-data-cache to pass all forms of unit tests (bloody, record, replay)

### DIFF
--- a/src/replay/proxy.coffee
+++ b/src/replay/proxy.coffee
@@ -88,6 +88,8 @@ class ProxyRequest extends HTTP.ClientRequest
     #assert !@ended, "Already called end"
     if data
       @write data, encoding
+    if @ended
+      return
     @ended = true
 
     @proxy this, (error, captured)=>


### PR DESCRIPTION
immediately return in "end" if already ended