### PR TITLE
Bring all changes up to version 2.0.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 node_js:
   - 0.10
+  - 0.12
+  - iojs
 notifications:
   email:
     - assaf@labnotes.org

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,65 @@
+# Version 2.0.6 2015-04-30
+
+FIXED pass through when sending request bodies
+
+
+# Version 2.0.5 2015-04-28
+
+FIXED SSL requests when not providing an explicit `protocol` option.
+
+
+# Version 2.0.4 2015-03-10
+
+FIXED problem with https support on 0.10
+
+
+# Version 2.0.3 2015-03-10
+
+ADDED Supports streaming API v2 (0.12/iojs)
+
+ADDED Supports new additions to HTTP API (0.12/iojs)
+
+CHANGED Replay.allow is now Replay.passThrough, a better name since the behavior
+is to pass through requests directly to the target server.
+
+CHANGED Replay.ignore is now Replay.drop, a better name since the behavior is to
+drop the connection (you'll get ECONNREFUSED).
+
+CHANGED New way for writing HTTP response line:
+
+  HTTP/1.1 200 OK
+  HTTP/1.1 404 Not Found
+
+CHANGED To enable debugging, run with environment variable DEBUG=replay
+
+FIXED HTTPS requests looping forvever
+
+
+## Version 1.12.0 2014-12-04
+
+ADDED you can now allow, ignore and localhost multiple domains
+
+```
+Replay.localhos('*.example.com');
+```
+
+
+## Version 1.11.0 2014-11-10
+
+ADDED now saving query string as part of request URL
+
+FIXED when ignoring request, throw ECONNREFUSED error
+
+FIXED handle case where header value is zero (number)
+
+
+## Version 1.10.3 2014-04-19
+
+ADDED 127.0.0.1 to default localhost addresses (Rajit Singh)
+
+FIXED double callback issue on catalog save (Itay Adler)
+
+
 ## Version 1.10.2 2014-04-19
 
 FIXED bug with header stringifying (for realz now)

--- a/README.md
+++ b/README.md
@@ -23,31 +23,31 @@ Things **node-replay** can do to make these problems go away:
 
 Like this:
 
-```
-$ npm install replay
+```bash
+npm install replay
 ```
 
 Now write some simple test case:
 
-```
-assert = require("assert")
-http = require("http")
-replay = require("replay")
+```javascript
+const assert  = require('assert');
+const HTTP    = require('http');
+const Replay  = require('Replay');
 
-http.get({ hostname: "www.iheartquotes.com", path: "/api/v1/random" }, function(response) {
-  response.body = "";
-  response.on("data", function(chunk) {
+HTTP.get({ hostname: 'www.iheartquotes.com', path: '/api/v1/random' }, function(response) {
+  var body = '';
+  response.on('data', function(chunk) {
     response.body = response.body + chunk;
-  })
-  response.on("end", function() {
+  });
+  response.on('end', function() {
 
     // Now check the request we made to the I <3 Quotes API
     assert.equal(response.statusCode, 200);
-    assert.equal(response.body, "Oxymoron 2. Exact estimate\n\n[codehappy] http://iheartquotes.com/fortune/show/38021\n");
-    console.log("Woot!");
+    assert.equal(response.body, 'Oxymoron 2. Exact estimate\n\n[codehappy] http://iheartquotes.com/fortune/show/38021\n');
+    console.log('Woot!');
 
-  })
-})
+  });
+});
 ```
 
 This, of course, will fail the first time you run it.  You'll see:
@@ -77,8 +77,8 @@ and capture the response.
 
 Let's do that:
 
-```
-$ REPLAY=record node test.js
+```bash
+REPLAY=record node test.js
 ```
 
 That wasn't too hard, but the test is still failing.  "How?" you must be
@@ -94,9 +94,9 @@ message, get the actual quote and make the assertion look for that value.
 
 Now run the test:
 
-```
+```bash
 $ node test.js
-Woot!
+=> Woot!
 ```
 
 Did the test pass?  Of course it did.  Run it again.  Still passing?  Why, yes.
@@ -104,8 +104,8 @@ Did the test pass?  Of course it did.  Run it again.  Still passing?  Why, yes.
 So let's have a look at that captured response.  All the respones recorded for
 'I <3 Quotes>' will be listed here:
 
-```
-$ ls fixtures/www.iheartquotes.com/
+```bash
+ls fixtures/www.iheartquotes.com/
 ```
 
 There should be only one file there, since we only recorded one response.  The
@@ -128,7 +128,7 @@ reads like this:
 ```
 /api/v1/random
 
-200 HTTP/1.1
+HTTP/1.1 200 OK
 server: nginx/0.7.67
 date: Fri, 02 Dec 2011 02:58:03 GMT
 content-type: text/plain
@@ -164,7 +164,7 @@ between the method and path, for example:
 ```
 GET REGEXP /\/Aregexp\d/i
 
-HTTP/1.1
+HTTP/1.1 200 OK
 Content-Type: text/html
 ```
 
@@ -196,15 +196,15 @@ this mode most of the time".
 You can set the mode by setting the environment variable `REPLAY` to one of
 these values:
 
-```
-$ REPLAY=record node test.js
+```bash
+REPLAY=record node test.js
 ```
 
 Of from your code by setting `replay.mode`:
 
-```
-var Replay = require("replay");
-Replay.mode = "record"
+```javascript
+const Replay = require('replay');
+Replay.mode = 'record';
 ```
 
 Of course, **node-replay** needs to store all those captured responses somewhere,
@@ -213,8 +213,8 @@ idea for a better directory name.  Easy to change.
 
 Like this:
 
-```
-Replay.fixtures = __dirname + "/fixtures/replay"
+```javascript
+Replay.fixtures = __dirname + '/fixtures/replay';
 ```
 
 You can tell **node-replay** what hosts to treat as "localhost".  Requests to
@@ -224,35 +224,31 @@ the same URL as production.
 
 For example:
 
-```
-Replay.localhost "www.example.com"
-```
-
-There may be hosts you don't care to record/replay: it doesn't matter if
-requests to these hosts succeed or not, and you don't care to manage their
-recorded file.  You can just add those to the ignore list:
-
-```
-Replay.ignore "www.google-analytics.com", "airbrake.io"
+```javascript
+Replay.localhost('www.example.com');
 ```
 
-Likewise, you can tell **node-reply** to allow network access to specific hosts:
+If you don't want requests going to specific server, you can add them to the
+drop list.  For example, Google Analytics, where you don't care that the request
+go through, and you don't want to record it.
 
-```
-Replay.allow "logger.example.com"
+```javascript
+Replay.drop('www.google-analytics.com', 'rollbar.com');
 ```
 
-Requests to allowed and ignored hosts will still replay any previously recorded
-responses, but if there is no recorded response, they will either fail (ignored)
-or pass through to the actual server (allowed).
+Likewise, you can tell **node-reply** to pass through requests to specific hosts:
+
+```javascript
+Replay.passThrough('s3.amazonaws.com');
+```
 
 If you're running into trouble, try turning debugging mode on.  It helps.
 Sometimes.
 
-```
+```bash
 $ DEBUG=replay node test.js
-Requesting http://www.iheartquotes.com:80/api/v1/random
-Woot!
+=> Requesting http://www.iheartquotes.com:80/api/v1/random
+=> Woot!
 ```
 
 By default, **node-replay** will record the following headers with each request,
@@ -272,8 +268,8 @@ expressions.
 
 For example, to capture `content-length` (useful with file uploads):
 
-```
-Replay.headers.push(/^content-length/)
+```javascript
+Replay.headers.push(/^content-length/);
 ```
 
 Since headers are case insensitive, we always match on the lower case name.
@@ -293,7 +289,7 @@ pass to the next proxy down the chain.
 
 The proxy chain looks something like this:
 
-- Logger dumps the request URL when running with `DEBUG=true`
+- Logger dumps the request URL when running with `DEBUG=replay`
 - The pass-through proxy will pass the request directly to the server in `bloody` mode, or when talking to `localhost`
 - The recorder proxy will either replay a captured request (if it has one), talk to the server and capture the response
   (in `record` mode), or pass to the next proxy

--- a/example/fixtures/www.iheartquotes.com/exact_estimate
+++ b/example/fixtures/www.iheartquotes.com/exact_estimate
@@ -1,6 +1,6 @@
 /api/v1/random
 
-200 HTTP/1.1
+HTTP/1.1 200 OK
 server: nginx/0.7.67
 date: Fri, 02 Dec 2011 02:58:03 GMT
 content-type: text/plain

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "replay",
   "description": "When API testing slows you down: record and replay HTTP responses like a boss",
-  "version": "1.10.3",
+  "version": "2.0.6",
   "author": "Assaf Arkin <assaf@labnotes.org> (http://labnotes.org/)",
   "keywords": [
     "test",
@@ -27,16 +27,17 @@
     "test":         "./node_modules/.bin/mocha"
   },
   "dependencies": {
-    "coffee-script":  "1.6.3",
+    "coffee-script":  "1.9.2",
+    "debug": "^2.0",
     "js-string-escape": "~1.0.0",
     "mkdirp": "~0.5.0"
   },
   "devDependencies": {
-    "body-parser":    "1.0.2",
-    "express":        "4.0.0",
-    "mocha":          "1.18.2",
-    "async":          "0.7.0",
-    "request":        "2.34.0"
+    "body-parser": "^1.12.3",
+    "express": "^4.12.3",
+    "mocha": "^2.2.4",
+    "async": "^0.9.0",
+    "request": "^2.55.0"
   },
   "repository": {
     "type": "git",

--- a/src/replay/catalog.coffee
+++ b/src/replay/catalog.coffee
@@ -77,8 +77,7 @@ class Catalog
     uid = +new Date + "" + Math.floor(Math.random() * 100000)
     tmpfile = "#{@getFixturesDir()}/node-replay.#{uid}"
     pathname = "#{@getFixturesDir()}/#{host.replace(":", "-")}"
-    logger = request.replay.logger
-    logger.log "Creating #{pathname}"
+    debug "Creating #{pathname}"
     mkdirp pathname, (error)->
       return callback error if error
       filename = "#{pathname}/#{uid}"

--- a/src/replay/catalog.coffee
+++ b/src/replay/catalog.coffee
@@ -12,21 +12,6 @@ existsSync = File.existsSync || Path.existsSync
 
 existsSync = File.existsSync || Path.existsSync
 
-
-mkdir = (pathname, callback)->
-  exists pathname, (found)->
-    if found
-      callback null
-      return
-    parent = Path.dirname(pathname)
-    exists parent, (found)->
-      if found
-        File.mkdir pathname, callback
-      else
-        mkdir parent, ->
-          File.mkdir pathname, callback
-
-
 class Catalog
   constructor: (@settings)->
     # We use this to cache host/host:port mapped to array of matchers.

--- a/src/replay/debug.coffee
+++ b/src/replay/debug.coffee
@@ -1,0 +1,1 @@
+module.exports = require("debug")("replay")

--- a/src/replay/logger.coffee
+++ b/src/replay/logger.coffee
@@ -1,21 +1,18 @@
-URL = require("url")
+debug = require("./debug")
+URL   = require("url")
 
 
 # Simple proxy that spits all request URLs to the console if the debug settings is true.
 #
 # Example
 #   replay.use replay.logger(exports)
-#   replay.debug = true
 logger = (settings)->
   return (request, callback)->
-    replay = request.replay
-    logger = replay.logger
-    logger.log "Replay: Requesting #{request.method} #{URL.format(request.url)}"
+    debug "Requesting #{request.method} #{URL.format(request.url)}"
     request.on "response", (response)->
-      logger.log "Replay: Received #{response.statusCode} #{URL.format(request.url)}"
+      debug "Received #{response.statusCode} #{URL.format(request.url)}"
     request.on "error", (error)->
-      unless replay.isIgnored(request.url.hostname)
-        replay.emit("error", error)
+      debug "Error #{error}"
 
     callback()
     return

--- a/src/replay/proxy.coffee
+++ b/src/replay/proxy.coffee
@@ -93,7 +93,7 @@ class ProxyRequest extends HTTP.ClientRequest
       setImmediate(callback)
 
   end: (data, encoding, callback)->
-    assert !@ended, "Already called end"
+    # assert !@ended, "Already called end"
 
     if (typeof data == 'function')
       [callback, data] = [data, null]

--- a/src/replay/proxy.coffee
+++ b/src/replay/proxy.coffee
@@ -102,6 +102,15 @@ class ProxyRequest extends HTTP.ClientRequest
     if data
       @body ||= []
       @body.push [data, encoding]
+
+    # Sometimes end is called twice
+    # We must exit this method early, otherwise nasty things can happen
+    if @ended
+      if (callback)
+        return setImmediate(callback)
+      else
+        return
+
     @ended = true
 
     if (callback)

--- a/src/replay/recorder.coffee
+++ b/src/replay/recorder.coffee
@@ -9,17 +9,27 @@ recorded = (settings)->
     if request.url.port && request.url.port != "80"
       host += ":#{request.url.port}"
     # Look for a matching response and replay it.
-    matchers = catalog.find(host)
-    if matchers
-      for matcher in matchers
-        response = matcher(request)
-        if response
-          callback null, response
-          return
+    try
+      matchers = catalog.find(host)
+      if matchers
+        for matcher in matchers
+          response = matcher(request)
+          if response
+            callback null, response
+            return
+    catch error
+      error.code = "CORRUPT FIXTURE"
+      error.syscall = "connect"
+      callback error
+      return
+
 
     # Do not record this host.
-    if settings.isIgnored(request.url.hostname)
-      callback null
+    if settings.isDropped(request.url.hostname)
+      refused = new Error("Error: connect ECONNREFUSED")
+      refused.code = refused.errno = "ECONNREFUSED"
+      refused.syscall = "connect"
+      callback refused
       return
 
     # In recording mode capture the response and store it.
@@ -29,7 +39,7 @@ recorded = (settings)->
         catalog.save host, request, response, (error)->
           callback error, response
       return
-   
+
     # Not in recording mode, pass control to the next proxy.
     callback null
 

--- a/src/replay/replay.coffee
+++ b/src/replay/replay.coffee
@@ -74,6 +74,10 @@ class Replay extends EventEmitter
   use: (proxy)->
     @chain.prepend(proxy)
 
+  # Alias allow to passThrough for backward compatibility
+  allow: (hosts...)->
+    @passThrough(hosts...)
+
   # Pass through all requests to these hosts
   passThrough: (hosts...)->
     @reset(hosts...)

--- a/test/fixtures/example.com-3002/json_weather
+++ b/test/fixtures/example.com-3002/json_weather
@@ -1,7 +1,7 @@
 GET /weather.json
 accept: "application/json"
 
-200 HTTP/1.1
+HTTP/1.1 200 OK
 Content-Type: text/html
 Date:         Tue, 29 Nov 2011 03:12:15 GMT
 

--- a/test/fixtures/example.com-3002/post_body
+++ b/test/fixtures/example.com-3002/post_body
@@ -1,6 +1,6 @@
 POST /post-body
 body: request body
 
-200 HTTP/1.1
+HTTP/1.1 200 OK
 
 response body

--- a/test/fixtures/example.com-3002/post_body_multi
+++ b/test/fixtures/example.com-3002/post_body_multi
@@ -1,6 +1,6 @@
 POST /post-body-multi
 body: line1\nline2\nline3
 
-200 HTTP/1.1
+HTTP/1.1 200 OK
 
 response body

--- a/test/fixtures/example.com-3002/query_1
+++ b/test/fixtures/example.com-3002/query_1
@@ -1,6 +1,7 @@
-POST /posts
+GET /query?param=1
 
-HTTP/1.1 201 OK
+HTTP/1.1 200 OK
 Content-Type: text/html
 Date:         Tue, 29 Nov 2011 03:12:15 GMT
-Location:     /posts/1
+
+1

--- a/test/fixtures/example.com-3002/query_2
+++ b/test/fixtures/example.com-3002/query_2
@@ -1,6 +1,7 @@
-POST /posts
+GET /query?param=2
 
-HTTP/1.1 201 OK
+HTTP/1.1 200 OK
 Content-Type: text/html
 Date:         Tue, 29 Nov 2011 03:12:15 GMT
-Location:     /posts/1
+
+2

--- a/test/fixtures/example.com-3002/regexp
+++ b/test/fixtures/example.com-3002/regexp
@@ -1,6 +1,6 @@
 GET REGEXP /\/regexp/
 
-200 HTTP/1.1
+HTTP/1.1 200 OK
 Content-Type: text/html
 
 regexp

--- a/test/fixtures/example.com-3002/regexpi
+++ b/test/fixtures/example.com-3002/regexpi
@@ -1,6 +1,6 @@
 GET REGEXP /\/Aregexp\d/i
 
-200 HTTP/1.1
+HTTP/1.1 200 OK
 Content-Type: text/html
 
 Aregexp2

--- a/test/fixtures/example.com-3002/weather_in_94606
+++ b/test/fixtures/example.com-3002/weather_in_94606
@@ -1,6 +1,6 @@
 GET /weather?c=94606
 
-200 HTTP/1.1
+HTTP/1.1 200 OK
 Content-Type: text/html
 Date:         Tue, 29 Nov 2011 03:12:15 GMT
 

--- a/test/fixtures/example.com-3555/minimal
+++ b/test/fixtures/example.com-3555/minimal
@@ -1,0 +1,1 @@
+GET /minimal

--- a/test/fixtures/other-fixtures-dir/example.com-3002/weather_in_94606
+++ b/test/fixtures/other-fixtures-dir/example.com-3002/weather_in_94606
@@ -1,6 +1,6 @@
 GET /weather?c=94606
 
-200 HTTP/1.1
+HTTP/1.1 200 OK
 Content-Type: text/html
 Date:         Tue, 30 Nov 2011 03:12:15 GMT
 

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,3 +1,3 @@
---compilers coffee:coffee-script
+--compilers coffee:coffee-script/register
 --globals url
 --reporter spec


### PR DESCRIPTION
I tried to use your fork of `node-replay` with Node 4 but it was not able to perform any request (too outdated). So I tried to use the latest release of `node-replay` from the upstream project and I was able to perform requests again. However the main project does not have all the changes you/jake/jude did (to support certificates among other things).

So this PR is a (careful) merge of all the changes brought in the upstream project up to version `2.0.6`, which is the latest published release **and** the last version written in CoffeeScript **and** the last version that supports node `0.10`.