### PR TITLE
Update npm script paths so they are compatible with npm@3

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,11 +20,11 @@
   },
   "files": [ "src" ],
   "scripts": {
-    "build":        "node node_modules/coffee-script/bin/coffee --bare --compile --output lib/replay src/replay/",
-    "postinstall":  "node node_modules/coffee-script/bin/coffee --bare --compile --output lib/replay src/replay/",
-    "prepublish":   "node node_modules/coffee-script/bin/coffee --bare --compile --output lib/replay src/replay/",
+    "build":        "coffee --bare --compile --output lib/replay src/replay/",
+    "postinstall":  "coffee --bare --compile --output lib/replay src/replay/",
+    "prepublish":   "coffee --bare --compile --output lib/replay src/replay/",
     "postpublish":  "rm -rf lib",
-    "test":         "./node_modules/.bin/mocha"
+    "test":         "mocha"
   },
   "dependencies": {
     "coffee-script":  "1.9.2",


### PR DESCRIPTION
The paths for the npm scripts (ex: `postinstall`) specify paths that are dependent on the directory structure that npm version < 3 uses. The `node_modules/.bin` stuff shouldn't be required, as npm prepends it to the `$PATH` when it executes npm scripts.

Error when installing from npm@3:

```
npm WARN prefer global coffee-script@1.9.2 should be installed with -g

> replay@2.0.6 postinstall ***/node_modules/replay
> node node_modules/coffee-script/bin/coffee --bare --compile --output lib/replay src/replay/

module.js:327
    throw err;
    ^

Error: Cannot find module '***/node_modules/replay/node_modules/coffee-script/bin/coffee'
    at Function.Module._resolveFilename (module.js:325:15)
    at Function.Module._load (module.js:276:25)
    at Function.Module.runMain (module.js:441:10)
    at startup (node.js:139:18)
    at node.js:968:3
npm WARN babel-eslint@5.0.4 requires a peer of eslint@<2.3.0 but none was installed.
npm ERR! Darwin 15.5.0
npm ERR! argv "***/.nvm/versions/node/v4.4.4/bin/node" "***/.nvm/versions/node/v4.4.4/bin/npm" "install" "--save" "gd-data-cache"
npm ERR! node v4.4.4
npm ERR! npm  v3.9.2
npm ERR! code ELIFECYCLE

npm ERR! replay@2.0.6 postinstall: `node node_modules/coffee-script/bin/coffee --bare --compile --output lib/replay src/replay/`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the replay@2.0.6 postinstall script 'node node_modules/coffee-script/bin/coffee --bare --compile --output lib/replay src/replay/'.
``
```
